### PR TITLE
fix(nix): make flake.nix work on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,10 @@
           inherit system overlays;
         };
 
-        # Define the runtime dependencies needed by Bevy
-        runtimeLibs = with pkgs; [
+        isLinux = pkgs.stdenv.hostPlatform.isLinux;
+
+        # Define the runtime dependencies needed by Bevy (Linux only)
+        runtimeLibs = pkgs.lib.optionals isLinux (with pkgs; [
           vulkan-loader
           libX11
           libXcursor
@@ -35,13 +37,14 @@
           libudev-zero
           alsa-lib
           dbus
-        ];
+        ]);
 
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" ];
           targets = [
-            "x86_64-unknown-linux-gnu"
             "wasm32-unknown-unknown"
+          ] ++ pkgs.lib.optionals isLinux [
+            "x86_64-unknown-linux-gnu"
           ];
         };
 
@@ -67,29 +70,33 @@
 
         devShells.default =
           with pkgs;
-          mkShell {
-            buildInputs = [
-              rustToolchain
-              pkg-config
-              openssl # TODO: remove this
-              wasm-bindgen-cli_0_2_108
-              just
-              wget
-              p7zip
-              binaryen
-              cargo-about
-              gitui
-            ]
-            ++ runtimeLibs
-            ++ [
-              mold
-              clang
-              stdenv.cc.cc
-            ];
+          mkShell (
+            {
+              buildInputs = [
+                rustToolchain
+                pkg-config
+                openssl # TODO: remove this
+                wasm-bindgen-cli_0_2_108
+                just
+                wget
+                p7zip
+                binaryen
+                cargo-about
+                gitui
+              ]
+              ++ runtimeLibs
+              ++ lib.optionals isLinux [
+                mold
+                clang
+                stdenv.cc.cc
+              ];
 
-            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (runtimeLibs ++ [ stdenv.cc.cc ]);
-          };
+              RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+            }
+            // lib.optionalAttrs isLinux {
+              LD_LIBRARY_PATH = lib.makeLibraryPath (runtimeLibs ++ [ stdenv.cc.cc ]);
+            }
+          );
       }
     );
 }


### PR DESCRIPTION
## Summary

`nix develop` 在 macOS 上会失败，因为 `runtimeLibs` 无条件引入了 Linux-only 的依赖（vulkan-loader、wayland、libudev-zero 等），导致 nix 拒绝 evaluate。

本 PR 用 `isLinux` 条件守卫将 Linux-only 的部分隔离：

- `runtimeLibs` 整体用 `pkgs.lib.optionals isLinux` 包裹
- `mold`、`clang`、`stdenv.cc.cc` 仅在 Linux 下加入 `buildInputs`
- `LD_LIBRARY_PATH` 仅在 Linux 下设置
- `x86_64-unknown-linux-gnu` rust target 仅在 Linux 下添加

macOS 用户现在可以直接 `nix develop` 进入开发环境。Linux 行为不变。